### PR TITLE
feat: resolve duckiebot host via tailscale aliases

### DIFF
--- a/devel/build/command.py
+++ b/devel/build/command.py
@@ -51,8 +51,9 @@ from dtproject.constants import ARCH_TO_PLATFORM, DISTRO_KEY, BUILD_COMPATIBILIT
 from dtproject.utils.misc import dtlabel
 
 from utils.duckietown_utils import DEFAULT_OWNER
-from utils.misc_utils import human_size, human_time, sanitize_hostname, parse_version, pretty_json
+from utils.misc_utils import human_size, human_time, parse_version, pretty_json
 from utils.multi_command_utils import MultiCommand
+from utils.resolve import get_duckiebot_host
 from utils.pip_utils import get_pip_index_url
 
 from dockertown.components.buildx.imagetools.models import Manifest
@@ -166,9 +167,6 @@ class DTCommand(DTCommandAbs):
             dtslogger.info(f"Overriding version {version!r} with {parsed.tag!r}")
             version = parsed.tag
 
-        # sanitize hostname
-        if parsed.machine is not None:
-            parsed.machine = sanitize_hostname(parsed.machine)
 
         # duckietown token
         if parsed.ci:
@@ -242,6 +240,10 @@ class DTCommand(DTCommandAbs):
             # update destination parameter
             if not parsed.destination:
                 parsed.destination = DEFAULT_MACHINE
+        if parsed.machine and parsed.machine != DEFAULT_MACHINE and '://' not in parsed.machine:
+            parsed.machine = get_duckiebot_host(parsed.machine)
+        if parsed.destination and parsed.destination != DEFAULT_MACHINE and '://' not in parsed.destination:
+            parsed.destination = get_duckiebot_host(parsed.destination)
 
         # add code labels
         project_head_version = project.head_version if project.is_clean() else "ND"

--- a/devel/run/command.py
+++ b/devel/run/command.py
@@ -25,8 +25,9 @@ from utils.docker_utils import (
     get_endpoint_architecture,
     get_registry_to_use, CLOUD_BUILDERS, get_cloud_builder, merge_docker_compose_services,
 )
-from utils.misc_utils import human_size, sanitize_hostname, pretty_exc, pretty_yaml, random_string
+from utils.misc_utils import human_size, pretty_exc, pretty_yaml, random_string
 from utils.multi_command_utils import MultiCommand
+from utils.resolve import get_duckiebot_host
 
 from .configuration import DEFAULT_TRUE
 
@@ -115,8 +116,8 @@ class DTCommand(DTCommandAbs):
         else:
             # local builder is the default
             if parsed.machine is not None:
-                # sanitize hostname
-                parsed.machine = sanitize_hostname(parsed.machine)
+                # resolve hostname
+                parsed.machine = get_duckiebot_host(parsed.machine)
             else:
                 parsed.machine = DEFAULT_MACHINE
 

--- a/utils/resolve.py
+++ b/utils/resolve.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+import os
+import socket
+import subprocess
+from typing import Iterable, Optional
+
+
+def _is_reachable(host: str, port: int = 22, timeout: float = 1.5) -> bool:
+    """Fast check: try TCP connect; if blocked, fall back to getaddrinfo + ping."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except Exception:
+        # DNS ok but SSH closed? Still verify host resolves and responds to ping.
+        try:
+            socket.getaddrinfo(host, None)
+        except socket.gaierror:
+            return False
+        try:
+            # -c 1 one packet, -W timeout seconds (Linux/BusyBox compatible)
+            subprocess.run(
+                ["ping", "-c", "1", "-W", str(int(timeout)), host],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True
+            )
+            return True
+        except Exception:
+            return False
+
+
+def _magicdns_candidates(bot_name: str) -> Iterable[str]:
+    # Optional: if a user exports TAILNET_DOMAIN=tailnet-xyz.ts.net we’ll try FQDN too
+    tailnet = os.environ.get("TAILNET_DOMAIN", "").strip()
+    if tailnet:
+        yield f"{bot_name}.{tailnet}"
+
+
+def get_duckiebot_host(
+    default_name: str = "duckiebot",
+    extra_candidates: Optional[Iterable[str]] = None,
+) -> str:
+    """Return the best hostname to reach the Duckiebot.
+    Precedence:
+      1) DUCKIEBOT_HOST (explicit override)
+      2) `default_name` (MagicDNS short name)
+      3) `default_name`.local (mDNS)
+      4) `default_name`.<TAILNET_DOMAIN> (MagicDNS FQDN, optional)
+      5) any extra candidates passed in
+    Raises RuntimeError if none are reachable.
+    """
+    override = os.environ.get("DUCKIEBOT_HOST")
+    if override:
+        return override
+
+    candidates = [default_name, f"{default_name}.local"]
+    candidates += list(_magicdns_candidates(default_name))
+    if extra_candidates:
+        candidates += list(extra_candidates)
+
+    tried = []
+    for host in candidates:
+        if _is_reachable(host):
+            return host
+        tried.append(host)
+
+    raise RuntimeError(
+        f"Could not reach Duckiebot via any hostname. Tried: {', '.join(tried)}.\n"
+        "Tip: export DUCKIEBOT_HOST=<ip-or-host>, or set TAILNET_DOMAIN=tailnet-xyz.ts.net."
+    )

--- a/utils/resolve.py
+++ b/utils/resolve.py
@@ -35,15 +35,15 @@ def _magicdns_candidates(bot_name: str) -> Iterable[str]:
 
 
 def get_duckiebot_host(
-    default_name: str = "duckiebot",
+    duckiebot_name: str = "duckiebot",
     extra_candidates: Optional[Iterable[str]] = None,
 ) -> str:
     """Return the best hostname to reach the Duckiebot.
     Precedence:
       1) DUCKIEBOT_HOST (explicit override)
-      2) `default_name` (MagicDNS short name)
-      3) `default_name`.local (mDNS)
-      4) `default_name`.<TAILNET_DOMAIN> (MagicDNS FQDN, optional)
+      2) `duckiebot_name`.local (mDNS)
+      3) `duckiebot_name` (MagicDNS short name)
+      4) `duckiebot_name`.<TAILNET_DOMAIN> (MagicDNS FQDN, optional)
       5) any extra candidates passed in
     Raises RuntimeError if none are reachable.
     """
@@ -51,8 +51,8 @@ def get_duckiebot_host(
     if override:
         return override
 
-    candidates = [default_name, f"{default_name}.local"]
-    candidates += list(_magicdns_candidates(default_name))
+    candidates = [ f"{duckiebot_name}.local", duckiebot_name]
+    candidates += list(_magicdns_candidates(duckiebot_name))
     if extra_candidates:
         candidates += list(extra_candidates)
 


### PR DESCRIPTION
## Summary
- add `get_duckiebot_host` utility to try multiple host aliases with MagicDNS/ENV overrides
- use helper in `dts devel run` and `dts devel build` to auto-resolve reachable Duckiebot hostname

## Testing
- `pytest`
- `python -m py_compile utils/resolve.py devel/run/command.py devel/build/command.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0c2ef8144832f832efa1e0597ab37